### PR TITLE
Experimenting with error management

### DIFF
--- a/tests/TestFuture.re
+++ b/tests/TestFuture.re
@@ -23,7 +23,9 @@ describe("Future", () => {
       s => {
         s |. equals("one!");
       },
-      _ => ()
+      _ => {
+        1 |. equals(2);
+      }
     )
   });
 
@@ -34,7 +36,9 @@ describe("Future", () => {
       | _ => assert false
     })
     |. Future.get(
-      _ => (),
+      _ => {
+        1 |. equals(2);
+      },
       err => {
         err |. deepEquals(Err("one!"));
       }
@@ -50,7 +54,9 @@ describe("Future", () => {
         s |. equals("20!");
         done_();
       },
-      _ => ()
+      _ => {
+        1 |. equals(2);
+      }
     );
   });
 
@@ -61,7 +67,9 @@ describe("Future", () => {
       | _ => assert false
     })
     |. Future.get(
-      _ => (),
+      _ => {
+        1 |. equals(2);
+      },
       error => {
         error |. deepEquals(Err("20!"));
         done_();
@@ -80,7 +88,9 @@ describe("Future", () => {
         n |. equals(90);
         v^ |. equals(100);
       },
-      _ => ()
+      _ => {
+        1 |. equals(2);
+      }
     );
   });
 
@@ -91,14 +101,18 @@ describe("Future", () => {
       n => {
         n |. equals(60);
       },
-      _ => ()
+      _ => {
+        1 |. equals(2);
+      }
     );
   });
 
   test("raising resolver", () => {
     Future.make((_resolve, _reject) => raise(Err("one")))
     |. Future.get(
-      _ => (),
+      _ => {
+        1 |. equals(2);
+      },
       e => {
         e |. deepEquals(Err("one"));
       }
@@ -109,7 +123,9 @@ describe("Future", () => {
     Future.value(59)
     |. Future.map(_ => raise(Err("one")))
     |. Future.get(
-      _ => (),
+      _ => {
+        1 |. equals(2);
+      },
       e => {
         e |. deepEquals(Err("one"));
       }
@@ -128,7 +144,9 @@ describe("Future", () => {
       c => {
         c |. equals(1);
       },
-      _ => ()
+      _ => {
+        1 |. equals(2);
+      }
     );
     count^ |. equals(1);
 
@@ -136,7 +154,9 @@ describe("Future", () => {
       c => {
         c |. equals(1);
       },
-      _ => ()
+      _ => {
+        1 |. equals(2);
+      }
     );
     count^ |. equals(1);
   });
@@ -154,7 +174,9 @@ describe("Future", () => {
       _ => {
         count^ |. equals(~m="Runs after previous future", 1);
       },
-      _ => ()
+      _ => {
+        1 |. equals(2);
+      }
     );
     count^ |. equals(~m="Callback is async (2)", 0);
 
@@ -162,7 +184,9 @@ describe("Future", () => {
       _ => {
         count^ |. equals(~m="Previous future only runs once", 1);
       },
-      _ => ()
+      _ => {
+        1 |. equals(2);
+      }
     );
     count^ |. equals(0, ~m="Callback is async (3)");
 
@@ -182,7 +206,9 @@ describe("Future Belt.Result", () => {
       r => {
         Belt.Result.getExn(r) |. equals("two!");
       },
-      _ => ()
+      _ => {
+        1 |. equals(2);
+      }
     );
 
     Belt.Result.Error("err2")
@@ -193,7 +219,9 @@ describe("Future Belt.Result", () => {
         | Ok(_) => raise(TestError("shouldn't be possible"))
         | Error(e) => e |. equals("err2");
       },
-      _ => ()
+      _ => {
+        1 |. equals(2);
+      }
     );
   });
 
@@ -205,7 +233,9 @@ describe("Future Belt.Result", () => {
       r => {
         Belt.Result.getExn(r) |. equals("three");
       },
-      _ => ()
+      _ => {
+        1 |. equals(2);
+      }
     );
 
     Belt.Result.Error("err3")
@@ -216,7 +246,9 @@ describe("Future Belt.Result", () => {
         | Ok(_) => raise(TestError("shouldn't be possible"))
         | Error(e) => e |. equals("err3!");
       },
-      _ => ()
+      _ => {
+        1 |. equals(2);
+      }
     );
   });
 
@@ -231,7 +263,9 @@ describe("Future Belt.Result", () => {
       _ => {
         x^ |. equals(11);
       },
-      _ => ()
+      _ => {
+        1 |. equals(2);
+      }
     );
 
     Belt.Result.Error(10)
@@ -241,7 +275,9 @@ describe("Future Belt.Result", () => {
       _ => {
         y^ |. equals(1);
       },
-      _ => ()
+      _ => {
+        1 |. equals(2);
+      }
     );
   });
 
@@ -256,7 +292,9 @@ describe("Future Belt.Result", () => {
       _ => {
         x^ |. equals(1);
       },
-      _ => ()
+      _ => {
+        1 |. equals(2);
+      }
     );
 
     Belt.Result.Error(10)
@@ -266,7 +304,9 @@ describe("Future Belt.Result", () => {
       _ => {
         y^ |. equals(11);
       },
-      _ => ()
+      _ => {
+        1 |. equals(2);
+      }
     );
   });
 

--- a/tests/TestFuture.re
+++ b/tests/TestFuture.re
@@ -4,28 +4,69 @@ exception TestError(string);
 type timeoutId;
 [@bs.val] [@bs.val] external setTimeout : ([@bs.uncurry] (unit => unit), int) => timeoutId = "";
 
+exception Err(string);
+
 describe("Future", () => {
 
-  let delay = (ms, f) => Future.make(resolve =>
+  let delay = (ms, f) => Future.make((resolve, _reject) =>
     setTimeout(() => f() |> resolve, ms) |> ignore
+  );
+
+  let delayError = (ms, f) => Future.make((_resolve, reject) =>
+    setTimeout(() => f() |> reject, ms) |> ignore
   );
 
   test("sync chaining", () => {
     Future.value("one")
     |. Future.map(s => s ++ "!")
-    |. Future.map(s => {
-      s |. equals("one!");
-    });
+    |. Future.get(
+      s => {
+        s |. equals("one!");
+      },
+      _ => ()
+    )
+  });
+
+  test("sync error chaining", () => {
+    Future.error(Err("one"))
+    |. Future.catch(e => switch (e) {
+      | Err(s) => Err(s ++ "!") |. Future.error
+      | _ => assert false
+    })
+    |. Future.get(
+      _ => (),
+      err => {
+        err |. deepEquals(Err("one!"));
+      }
+    )
   });
 
   testAsync("async chaining", done_ => {
     delay(25, () => 20)
     |. Future.map(s => string_of_int(s))
     |. Future.map(s => s ++ "!")
-    |. Future.get(s => {
-      s |. equals("20!");
-      done_();
-    });
+    |. Future.get(
+      s => {
+        s |. equals("20!");
+        done_();
+      },
+      _ => ()
+    );
+  });
+
+  testAsync("async error chaining", done_ => {
+    delayError(25, () => Err("20"))
+    |. Future.catch(err => switch (err) {
+      | Err(s) => Err(s ++ "!") |. Future.error
+      | _ => assert false
+    })
+    |. Future.get(
+      _ => (),
+      error => {
+        error |. deepEquals(Err("20!"));
+        done_();
+      }
+    );
   });
 
   test("tap", () => {
@@ -34,36 +75,48 @@ describe("Future", () => {
     Future.value(99)
     |. Future.tap(n => v := n+1)
     |. Future.map(n => n - 9)
-    |. Future.get(n => {
-      n |. equals(90);
-      v^ |. equals(100);
-    });
+    |. Future.get(
+      n => {
+        n |. equals(90);
+        v^ |. equals(100);
+      },
+      _ => ()
+    );
   });
 
   test("flatMap", () => {
     Future.value(59)
     |. Future.flatMap(n => Future.value(n + 1))
-    |. Future.get(n => {
-      n |. equals(60);
-    });
+    |. Future.get(
+      n => {
+        n |. equals(60);
+      },
+      _ => ()
+    );
   });
 
   test("multiple gets", () => {
     let count = ref(0);
-    let future = Future.make(resolve => {
+    let future = Future.make((resolve, _reject) => {
       count := count^ + 1;
       resolve(count^);
     });
     count^ |. equals(1);
 
-    future |. Future.get(c => {
-      c |. equals(1);
-    });
+    future |. Future.get(
+      c => {
+        c |. equals(1);
+      },
+      _ => ()
+    );
     count^ |. equals(1);
 
-    future |. Future.get(c => {
-      c |. equals(1);
-    });
+    future |. Future.get(
+      c => {
+        c |. equals(1);
+      },
+      _ => ()
+    );
     count^ |. equals(1);
   });
 
@@ -76,17 +129,23 @@ describe("Future", () => {
 
     count^ |. equals(~m="Callback is async", 0);
 
-    future |. Future.get(_ => {
-      count^ |. equals(~m="Runs after previous future", 1);
-    });
+    future |. Future.get(
+      _ => {
+        count^ |. equals(~m="Runs after previous future", 1);
+      },
+      _ => ()
+    );
     count^ |. equals(~m="Callback is async (2)", 0);
 
-    future |. Future.get(_ => {
-      count^ |. equals(~m="Previous future only runs once", 1);
-    });
+    future |. Future.get(
+      _ => {
+        count^ |. equals(~m="Previous future only runs once", 1);
+      },
+      _ => ()
+    );
     count^ |. equals(0, ~m="Callback is async (3)");
 
-    future |. Future.get(_ => done_());
+    future |. Future.get(_ => done_(), _ => ());
   });
 
 });
@@ -98,34 +157,46 @@ describe("Future Belt.Result", () => {
     Belt.Result.Ok("two")
     |. Future.value
     |. Future.mapOk(s => s ++ "!")
-    |. Future.get(r => {
-      Belt.Result.getExn(r) |. equals("two!");
-    });
+    |. Future.get(
+      r => {
+        Belt.Result.getExn(r) |. equals("two!");
+      },
+      _ => ()
+    );
 
     Belt.Result.Error("err2")
     |. Future.value
     |. Future.mapOk(s => s ++ "!")
-    |. Future.get(r => switch (r) {
-      | Ok(_) => raise(TestError("shouldn't be possible"))
-      | Error(e) => e |. equals("err2");
-    });
+    |. Future.get(
+      r => switch (r) {
+        | Ok(_) => raise(TestError("shouldn't be possible"))
+        | Error(e) => e |. equals("err2");
+      },
+      _ => ()
+    );
   });
 
   test("mapError", () => {
     Belt.Result.Ok("three")
     |. Future.value
     |. Future.mapError(s => s ++ "!")
-    |. Future.get(r => {
-      Belt.Result.getExn(r) |. equals("three");
-    });
+    |. Future.get(
+      r => {
+        Belt.Result.getExn(r) |. equals("three");
+      },
+      _ => ()
+    );
 
     Belt.Result.Error("err3")
     |. Future.value
     |. Future.mapError(s => s ++ "!")
-    |. Future.get(r => switch (r) {
-      | Ok(_) => raise(TestError("shouldn't be possible"))
-      | Error(e) => e |. equals("err3!");
-    });
+    |. Future.get(
+      r => switch (r) {
+        | Ok(_) => raise(TestError("shouldn't be possible"))
+        | Error(e) => e |. equals("err3!");
+      },
+      _ => ()
+    );
   });
 
   test("tapOk", () => {
@@ -135,16 +206,22 @@ describe("Future Belt.Result", () => {
     Belt.Result.Ok(10)
     |. Future.value
     |. Future.tapOk(n => x := x^ + n)
-    |. Future.get(_ => {
-      x^ |. equals(11);
-    });
+    |. Future.get(
+      _ => {
+        x^ |. equals(11);
+      },
+      _ => ()
+    );
 
     Belt.Result.Error(10)
     |. Future.value
     |. Future.tapOk(n => y := y^ + n)
-    |. Future.get(_ => {
-      y^ |. equals(1);
-    });
+    |. Future.get(
+      _ => {
+        y^ |. equals(1);
+      },
+      _ => ()
+    );
   });
 
   test("tapError", () => {
@@ -154,16 +231,22 @@ describe("Future Belt.Result", () => {
     Belt.Result.Ok(10)
     |. Future.value
     |. Future.tapError(n => x := x^ + n)
-    |. Future.get(_ => {
-      x^ |. equals(1);
-    });
+    |. Future.get(
+      _ => {
+        x^ |. equals(1);
+      },
+      _ => ()
+    );
 
     Belt.Result.Error(10)
     |. Future.value
     |. Future.tapError(n => y := y^ + n)
-    |. Future.get(_ => {
-      y^ |. equals(11);
-    });
+    |. Future.get(
+      _ => {
+        y^ |. equals(11);
+      },
+      _ => ()
+    );
   });
 
 });

--- a/tests/TestFuture.re
+++ b/tests/TestFuture.re
@@ -95,6 +95,27 @@ describe("Future", () => {
     );
   });
 
+  test("raising resolver", () => {
+    Future.make((_resolve, _reject) => raise(Err("one")))
+    |. Future.get(
+      _ => (),
+      e => {
+        e |. deepEquals(Err("one"));
+      }
+    )
+  });
+
+  test("raising callback", () => {
+    Future.value(59)
+    |. Future.map(_ => raise(Err("one")))
+    |. Future.get(
+      _ => (),
+      e => {
+        e |. deepEquals(Err("one"));
+      }
+    )
+  });
+
   test("multiple gets", () => {
     let count = ref(0);
     let future = Future.make((resolve, _reject) => {

--- a/tests/TestFuture.re
+++ b/tests/TestFuture.re
@@ -119,8 +119,8 @@ describe("Future", () => {
     )
   });
 
-  test("raising callback", () => {
-    Future.value(59)
+  testAsync("raising map", done_ => {
+    delay(20, () => 59)
     |. Future.map(_ => raise(Err("one")))
     |. Future.get(
       _ => {
@@ -128,6 +128,50 @@ describe("Future", () => {
       },
       e => {
         e |. deepEquals(Err("one"));
+        done_();
+      }
+    )
+  });
+
+  testAsync("raising flatMap", done_ => {
+    delay(20, () => 59)
+    |. Future.flatMap(_ => raise(Err("one")))
+    |. Future.get(
+      _ => {
+        1 |. equals(2);
+      },
+      e => {
+        e |. deepEquals(Err("one"));
+        done_();
+      }
+    )
+  });
+
+  testAsync("raising tap", done_ => {
+    delay(20, () => 59)
+    |. Future.tap(_ => raise(Err("one")))
+    |. Future.get(
+      _ => {
+        1 |. equals(2);
+      },
+      e => {
+        e |. deepEquals(Err("one"));
+        done_();
+      }
+    )
+  });
+
+  testAsync("raising catch", done_ => {
+    delay(20, () => 59)
+    |. Future.tap(_ => assert false)
+    |. Future.catch(_ => raise(Err("one")))
+    |. Future.get(
+      _ => {
+        1 |. equals(2);
+      },
+      e => {
+        e |. deepEquals(Err("one"));
+        done_();
       }
     )
   });


### PR DESCRIPTION
This PR allows to reject a future by calling `Future.error` or by raising in a callback.

After our small exchange yesterday on discord, I got interested and started experimenting with handling exceptions, and this is the result :)

One thing to consider before merging this is that catching exceptions doesn't seem to be sound in bucklescript, at least to my understanding, because js can throw whatever, not just `Error` objects.
I don't know if this is a showstopper for you, but I thought a PR could at least serve as a reference
if it is.

Otherwise, I was not sure what to name the equivalent of `catch` because naming it `flatMapError` was out of the question, so I named it... `catch`, but you might have a better idea?

