### PR TITLE
Resolve #4 FutureJs.fromPromise

### DIFF
--- a/src/FutureJs.re
+++ b/src/FutureJs.re
@@ -1,0 +1,33 @@
+
+/**
+ * Translate a Js.Promise to a Future(Belt.Result.t)
+ * 
+ * errorTransformer: (Js.Promise.error) => 'a
+ * - The errorTransformer will provide you with the raw Js.Promise.error
+ *   object.  This is done so that you may decide on the appropriate error
+ *   handling scheme for your application.
+ *   See: http://keleshev.com/composable-error-handling-in-ocaml
+ * - A good start is translating the Js.Promise.error to a string.
+ *   ```reason
+ *   let errorTransformer = (error) =>
+ *     Js.String.make(error)
+ *     |> (str => /*... do your transforms here */ str);
+*    ```
+ */
+let fromPromise = (promise, errorTransformer) => 
+  Future.make((callback) =>
+    promise
+    |> Js.Promise.then_(res =>
+      Belt.Result.Ok(res)
+      |> callback
+      |> ignore
+      |> Js.Promise.resolve
+    )
+    |> Js.Promise.catch(error =>
+      errorTransformer(error)
+      |> (transformed => Belt.Result.Error(transformed))
+      |> callback
+      |> ignore
+      |> Js.Promise.resolve
+    )
+  );

--- a/tests/TestFutureJs.re
+++ b/tests/TestFutureJs.re
@@ -1,0 +1,28 @@
+open BsOspec.Cjs;
+exception TestError(string);
+
+describe("FutureJs", () => {
+  let errorTransformer = Js.String.make;
+
+  testAsync("fromPromise (resolved)", done_ => {
+    Js.Promise.resolve(42)
+    |. FutureJs.fromPromise(errorTransformer)
+    |. Future.get(r => {
+      Belt.Result.getExn(r) |. equals(42);
+      done_();
+    });
+  });
+
+  testAsync("fromPromise (rejected)", done_ => {
+    let expected = "TestFutureJs.TestError,2,oops!";
+    Js.Promise.reject(TestError("oops!"))
+    |. FutureJs.fromPromise(errorTransformer)
+    |. Future.get(r =>
+      switch(r) {
+      | Belt.Result.Ok(_) => raise(TestError("shouldn't be possible"))
+      | Belt.Result.Error(s) => s |. equals(expected)
+      }
+      |> _ => done_()
+      );
+  });
+});


### PR DESCRIPTION
- Transformer (Js.Promise.t => Future)

I decided to remove the `Js.String.make` call from the internal implementation and pass the raw `Js.Promise.error` object to the `errorTransformer` user provided function.  I believe this way is the least intrusive way of allowing the caller to implement the error calling pattern.