### PR TITLE
Test coverage

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+repo_token: S9yt7QREzbSO9gGxjgDdXhKRnW5D31XYm

--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,1 +1,0 @@
-repo_token: S9yt7QREzbSO9gGxjgDdXhKRnW5D31XYm

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ npm-debug.log
 /node_modules/
 package-lock.json
 *.bs.js
+.nyc_output/
+coverage/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![npm](https://img.shields.io/npm/v/reason-future.svg)](https://www.npmjs.com/package/reason-future)
 [![Build Status](https://travis-ci.org/RationalJS/future.svg?branch=master)](https://travis-ci.org/RationalJS/future)
+[![Coverage Status](https://coveralls.io/repos/github/RationalJS/future/badge.svg?branch=test-coverage)](https://coveralls.io/github/RationalJS/future?branch=test-coverage)
 
 # The Future is Now
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,11 @@
     "build": "bsb -make-world",
     "start": "bsb -make-world -w",
     "clean": "bsb -clean-world",
-    "test": "ospec"
+    "coverage:report": "nyc --reporter=text-lcov ospec",
+    "posttest": "npm run coverage:report",
+    "test": "yarn clean ; yarn build ; istanbul cover --print both ospec",
+    "test:only": "ospec",
+    "test:cover": "yarn clean ; yarn build ; istanbul cover --print both ospec"
   },
   "files": [
     "src/Future.re",
@@ -22,6 +26,9 @@
   "devDependencies": {
     "bs-ospec": "^1.0.0",
     "bs-platform": "^3.1.0",
+    "coveralls": "^3.0.1",
+    "istanbul": "^0.4.5",
+    "nyc": "^11.8.0",
     "ospec": "^1.4.1"
   },
   "description": "A Js.Promise alternative for ReasonML.",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "build": "bsb -make-world",
     "start": "bsb -make-world -w",
     "clean": "bsb -clean-world",
-    "coverage:report": "nyc --reporter=text-lcov ospec",
+    "coverage:report": "nyc --reporter=text-lcov ospec | coveralls",
     "posttest": "npm run coverage:report",
     "test": "yarn clean ; yarn build ; istanbul cover --print both ospec",
     "test:only": "ospec",

--- a/tests/TestFuture.re
+++ b/tests/TestFuture.re
@@ -134,6 +134,14 @@ describe("Future Belt.Result", () => {
     |. Future.flatMapOk(s => Belt.Result.Ok(s ++ "!") |. Future.value)
     |. Future.get(r => Belt.Result.getExn(r) |. equals("four!"));
 
+    Belt.Result.Error("err4.1")
+    |. Future.value
+    |. Future.flatMapOk(s => Belt.Result.Ok(s ++ "!") |. Future.value)
+    |. Future.get(r => switch (r) {
+      | Ok(_) => raise(TestError("shouldn't be possible"))
+      | Error(e) => e |. equals("err4.1");
+    });
+
     Belt.Result.Error("err4")
     |. Future.value
     |. Future.flatMapError(e => Belt.Result.Error(e ++ "!") |. Future.value)


### PR DESCRIPTION
- Add a test to cover an uncovered flatMapOk case.
- Add test:only command to just run `ospec`
- Add test:cover command to run coverage with human readable coverage output.
- Change test to generate test coverage
- add a coverage:report command and add it to the posttest.

Coverage can be tracked with http://coveralls.io, The following tasks
need to be completed:
1. [x] Install the [node-coveralls] package.
2. [x] Set up the repository on http://coveralls.io
3. [x] Add a `.coveralls.yml` file with the proper repo token.
4. [x] Update the `coverage:report` command to the following
```json
{
  "coverage:report": "nyc --reporter=text-lcov ospec | coveralls"
}
```

[node-coveralls]: https://github.com/nickmerwin/node-coveralls#nyc