### PR TITLE
fixed bugs in promise rejection tests

### DIFF
--- a/tests/TestFutureJs.re
+++ b/tests/TestFutureJs.re
@@ -2,7 +2,7 @@ open BsOspec.Cjs;
 exception TestError(string);
 
 describe("FutureJs", () => {
-  let errorTransformer = Js.String.make;
+  let errorTransformer = x => x;
 
   testAsync("fromPromise (resolved)", done_ => {
     Js.Promise.resolve(42)
@@ -14,29 +14,29 @@ describe("FutureJs", () => {
   });
 
   testAsync("fromPromise (rejected)", done_ => {
-    let expected = "TestFutureJs.TestError,2,oops!";
-    Js.Promise.reject(TestError("oops!"))
+    let err = TestError("oops!");
+    Js.Promise.reject(err)
     |. FutureJs.fromPromise(errorTransformer)
     |. Future.get(r =>
       switch(r) {
       | Belt.Result.Ok(_) => raise(TestError("shouldn't be possible"))
-      | Belt.Result.Error(s) => s |. equals(expected)
+      | Belt.Result.Error(e) => e |. equals(err)
       }
       |> _ => done_()
       );
   });
 
   testAsync("fromPromise (internal rejection)", done_ => {
-    let expected = "TestFutureJs.TestError,2,boom!";
+    let err = TestError("boom!");
     let promise = Js.Promise.make((~resolve as _, ~reject) => {
-      reject(. TestError("boom!"));
+      reject(. err);
     });
 
     FutureJs.fromPromise(promise, errorTransformer)
     |. Future.get(r => {
       switch(r) {
       | Belt.Result.Ok(_) => raise(TestError("shouldn't be possible"))
-      | Belt.Result.Error((s)) => s |. equals(expected)
+      | Belt.Result.Error((e)) => e |. equals(err)
       };
 
       done_();
@@ -44,16 +44,16 @@ describe("FutureJs", () => {
   });
 
   testAsync("fromPromise (internal exception)", done_ => {
-    let expected = "TestFutureJs.TestError,2,explode!";
+    let err = TestError("explode!");
     let promise = Js.Promise.make((~resolve as _, ~reject as _) => {
-      raise(TestError("explode!"));
+      raise(err);
     });
 
     FutureJs.fromPromise(promise, errorTransformer)
     |. Future.get(r => {
       switch(r) {
       | Belt.Result.Ok(_) => raise(TestError("shouldn't be possible"))
-      | Belt.Result.Error((s)) => s |. equals(expected)
+      | Belt.Result.Error((s)) => s |. equals(err)
       };
 
       done_();
@@ -61,8 +61,8 @@ describe("FutureJs", () => {
   });
 
   testAsync("fromPromise (wrapped callback)", done_ => {
-    let expected = "TestFutureJs.TestError,2,throwback!";
-    let nodeFn = (callback) => callback(TestError("throwback!"));
+    let err = TestError("throwback!");
+    let nodeFn = (callback) => callback(err);
     let promise = Js.Promise.make((~resolve as _, ~reject) => {
       nodeFn((err) => reject(. err));
     });
@@ -71,7 +71,7 @@ describe("FutureJs", () => {
     |. Future.get(r => {
       switch(r) {
       | Belt.Result.Ok(_) => raise(TestError("shouldn't be possible"))
-      | Belt.Result.Error((s)) => s |. equals(expected)
+      | Belt.Result.Error((s)) => s |. equals(err)
       };
 
       done_();
@@ -79,8 +79,8 @@ describe("FutureJs", () => {
   });
 
   testAsync("fromPromise (layered failure)", done_ => {
-    let expected = "TestFutureJs.TestError,2,confused!";
-    let nodeFn = (callback) => callback(TestError("confused!"));
+    let err = TestError("confused!");
+    let nodeFn = (callback) => callback(err);
     let promise = Js.Promise.make((~resolve as _, ~reject) => {
       nodeFn((err) => reject(. err));
     });
@@ -91,7 +91,7 @@ describe("FutureJs", () => {
     |. Future.get(r => {
       switch(r) {
       | Belt.Result.Ok(_) => raise(TestError("shouldn't be possible"))
-      | Belt.Result.Error((s)) => s |. equals(expected)
+      | Belt.Result.Error((s)) => s |. equals(err)
       };
 
       done_();


### PR DESCRIPTION
when you use `Js.String.make()` as your error transformer, i'm guessing that maps to javascripts' `String()` function, which means you'll get a string based on the specific JS representation that bucklescript has chosen for your error value.

these changes should work no matter how `bsb` decides to represent those values