### PR TITLE
upgrade to bs-platform 4.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,11 +30,11 @@
   "license": "MIT",
   "devDependencies": {
     "bs-ospec": "^1.0.0",
-    "bs-platform": "^3.1.0",
-    "coveralls": "^3.0.1",
+    "bs-platform": "^4.0.1",
+    "coveralls": "^3.0.2",
     "istanbul": "^0.4.5",
-    "nyc": "^11.8.0",
-    "ospec": "^1.4.1"
+    "nyc": "^12.0.2",
+    "ospec": "1.4.1"
   },
   "description": "A Js.Promise alternative for ReasonML.",
   "main": "index.js",


### PR DESCRIPTION
Upgrade to the latest and greatest.  Also, I locked `ospec` to v1.4.1 because they're on version 3.x and upgrading to that breaks all the asynchronous tests.