### PR TITLE
Add map2...map5 for Future and Future of Result

### DIFF
--- a/src/Future.re
+++ b/src/Future.re
@@ -36,6 +36,18 @@ let flatMap = (Future(get), f) => make(resolve => {
   })
 });
 
+let map2 = (fa, fb, f) =>
+  flatMap(fa, a => map(fb, b => f(a, b)));
+
+let map3 = (fa, fb, fc, f) =>
+  map2(map2(fa, fb, f), fc, v => v);
+
+let map4 = (fa, fb, fc, fd, f) =>
+  map3(map2(fa, fb, f), fc, fd, v => v);
+
+let map5 = (fa, fb, fc, fd, fe, f) =>
+  map4(map2(fa, fb, f), fc, fd, fe, v => v);
+
 let tap = (Future(get) as future, f) => {
   get(f);
   future
@@ -65,6 +77,18 @@ let flatMapError = (future, f) => future |. flatMap(r =>
   | Belt.Result.Ok(v) => value(Belt.Result.Ok(v))
   | Belt.Result.Error(e) => f(e)
   });
+
+let mapOk2 = (fa, fb, f) =>
+  flatMapOk(fa, a => mapOk(fb, b => f(a, b)));
+
+let mapOk3 = (fa, fb, fc, f) =>
+  mapOk2(mapOk2(fa, fb, f), fc, v => v);
+
+let mapOk4 = (fa, fb, fc, fd, f) =>
+  mapOk3(mapOk2(fa, fb, f), fc, fd, v => v);
+
+let mapOk5 = (fa, fb, fc, fd, fe, f) =>
+  mapOk4(mapOk2(fa, fb, f), fc, fd, fe, v => v);
 
 let tapOk = (future, f) => future |. tap(r => switch(r) {
   | Belt.Result.Ok(v) => f(v) |. ignore


### PR DESCRIPTION
These functions allow you to wait for multiple futures to resolve and "map" the separate values from all of those futures into a new value.

Here is [the corresponding functionality](https://github.com/elm/core/blob/02443df8ae5fa5acf4814cfaa08a5244e19f884f/src/Task.elm#L123-L138) for the `Task` type in Elm as well as [a similar idea in this promise library for Haxe](https://github.com/fponticelli/thx.promise/blob/master/src/thx/promise/Promise.hx#L330-L331).

I chose to use the `mapN` name (as Elm does) because it seems more easily-understandable than a name like `liftA2` used in Haskell. I also chose to implement `map5` in terms of `map4` mostly because it's much more terse than lots of nested `flatMap`s, but the code might be a little less readable as a result.