### PR TITLE
Implement FutureJs.toPromise

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,11 @@ Convenience functions for interop with JavaScript land.
     a `Belt.Result.Error`.  This allows you to implement the error handling
     method which best meets your application's needs.
 - `FutureJs.toPromise(future)`
-  - `future` is the `Future.t(Belt.Result('a, 'e))` that is transformed into a
-    `Js.Promise.t('a)`
+  - `future` is any `Future.t('a)` which is transformed into a
+    `Js.Promise.t('a)`. Always resolves, never rejects the promise.
+- `FutureJs.resultToPromise(future)`
+  - `future` is the `Future.t(Belt.Result('a, 'e))` which is transformed into a
+    `Js.Promise.t('a)`. Resolves the promise on Ok result and rejects on Error result.
 
 Example use:
 

--- a/README.md
+++ b/README.md
@@ -115,11 +115,14 @@ Convenience functions for interop with JavaScript land.
 
 - `FutureJs.fromPromise(promise, errorTransformer)`
   - `promise` is the `Js.Promise.t('a)` that will be transformed into a
-    `Future`
+    `Future.t(Belt.Result.t('a, 'e))`
   - `errorTransformer` allows you to determine how `Js.Promise.error`
     objects will be transformed before they are returned wrapped within
     a `Belt.Result.Error`.  This allows you to implement the error handling
     method which best meets your application's needs.
+- `FutureJs.toPromise(future)`
+  - `future` is the `Future.t(Belt.Result('a, 'e))` that is transformed into a
+    `Js.Promise.t('a)`
 
 Example use:
 

--- a/src/FutureJs.re
+++ b/src/FutureJs.re
@@ -33,6 +33,12 @@ let fromPromise = (promise, errorTransformer) =>
   );
 
 let toPromise = (future) =>
+  Js.Promise.make((~resolve, ~reject as _) =>
+    future
+    |. Future.get(value => resolve(. value))
+  );
+
+let resultToPromise = (future) =>
   Js.Promise.make((~resolve, ~reject) =>
     future
     |. Future.map(result => switch(result) {

--- a/src/FutureJs.re
+++ b/src/FutureJs.re
@@ -31,3 +31,13 @@ let fromPromise = (promise, errorTransformer) =>
       |> Js.Promise.resolve
     )
   );
+
+let toPromise = (future) =>
+  Js.Promise.make((~resolve, ~reject) =>
+    future
+    |. Future.map(result => switch(result) {
+      | Belt.Result.Ok(result) => resolve(. result)
+      | Belt.Result.Error(error) => reject(. error)
+      })
+    |. ignore
+  );

--- a/tests/TestFuture.re
+++ b/tests/TestFuture.re
@@ -1,12 +1,5 @@
 open BsOspec.Cjs;
-exception TestError(string);
-
-type timeoutId;
-[@bs.val] [@bs.val] external setTimeout : ([@bs.uncurry] (unit => unit), int) => timeoutId = "";
-
-let delay = (ms, f) => Future.make(resolve =>
-  setTimeout(() => f() |> resolve, ms) |> ignore
-);
+open TestUtil;
 
 describe("Future", () => {
 

--- a/tests/TestFutureJs.re
+++ b/tests/TestFutureJs.re
@@ -1,15 +1,8 @@
 open BsOspec.Cjs;
-exception TestError(string);
-
-type timeoutId;
-[@bs.val] [@bs.val] external setTimeout : ([@bs.uncurry] (unit => unit), int) => timeoutId = "";
+open TestUtil;
 
 describe("FutureJs", () => {
   let errorTransformer = x => x;
-
-  let delay = (ms, f) => Future.make(resolve =>
-    setTimeout(() => f() |> resolve, ms) |> ignore
-  );
 
   testAsync("fromPromise (resolved)", done_ => {
     Js.Promise.resolve(42)
@@ -104,12 +97,6 @@ describe("FutureJs", () => {
       done_();
     });
   });
-
-  let checkPromisedValue = (done_, expected, actual) => {
-    equals(expected, actual);
-    done_();
-    Js.Promise.resolve(());
-  };
 
   testAsync("toPromise (trivial Ok result)", done_ => {
     Future.value(Belt.Result.Ok("payload"))

--- a/tests/TestFutureJs.re
+++ b/tests/TestFutureJs.re
@@ -98,30 +98,14 @@ describe("FutureJs", () => {
     });
   });
 
-  testAsync("toPromise (trivial Ok result)", done_ => {
-    Future.value(Belt.Result.Ok("payload"))
-    |> FutureJs.toPromise
-    |> Js.Promise.catch(_ => raise(TestError("shouldn't be possible")))
-    |> Js.Promise.then_(checkPromisedValue(done_, "payload"));
-  });
-
-  testAsync("toPromise (trivial Error result)", done_ => {
-    let err = TestError("error!");
-
-    Future.value(Belt.Result.Error(err))
-    |> FutureJs.toPromise
-    |> Js.Promise.then_(_ => raise(TestError("shouldn't be possible")))
-    |> Js.Promise.catch(checkPromisedValue(done_, err));
-  });
-
-  testAsync("toPromise (Ok result from delayed future)", done_ => {
+  testAsync("toPromise (Ok result)", done_ => {
     delay(5, () => Belt.Result.Ok("payload"))
     |> FutureJs.toPromise
     |> Js.Promise.catch(_ => raise(TestError("shouldn't be possible")))
     |> Js.Promise.then_(checkPromisedValue(done_, "payload"));
   });
 
-  testAsync("toPromise (Error result from delayed future)", done_ => {
+  testAsync("toPromise (Error result)", done_ => {
     let err = TestError("error!");
 
     delay(5, () => Belt.Result.Error(err))

--- a/tests/TestFutureJs.re
+++ b/tests/TestFutureJs.re
@@ -98,18 +98,24 @@ describe("FutureJs", () => {
     });
   });
 
-  testAsync("toPromise (Ok result)", done_ => {
-    delay(5, () => Belt.Result.Ok("payload"))
+  testAsync("toPromise", done_ => {
+    delay(5, () => "payload")
     |> FutureJs.toPromise
     |> Js.Promise.catch(_ => raise(TestError("shouldn't be possible")))
     |> Js.Promise.then_(checkPromisedValue(done_, "payload"));
   });
 
-  testAsync("toPromise (Error result)", done_ => {
-    let err = TestError("error!");
+  testAsync("resultToPromise (Ok result)", done_ => {
+    delay(5, () => Belt.Result.Ok("payload"))
+    |> FutureJs.resultToPromise
+    |> Js.Promise.catch(_ => raise(TestError("shouldn't be possible")))
+    |> Js.Promise.then_(checkPromisedValue(done_, "payload"));
+  });
 
+  testAsync("resultToPromise (Error result)", done_ => {
+    let err = TestError("error!");
     delay(5, () => Belt.Result.Error(err))
-    |> FutureJs.toPromise
+    |> FutureJs.resultToPromise
     |> Js.Promise.then_(_ => raise(TestError("shouldn't be possible")))
     |> Js.Promise.catch(checkPromisedValue(done_, err));
   });

--- a/tests/TestUtil.re
+++ b/tests/TestUtil.re
@@ -1,0 +1,14 @@
+exception TestError(string);
+
+type timeoutId;
+[@bs.val] [@bs.val] external setTimeout : ([@bs.uncurry] (unit => unit), int) => timeoutId = "";
+
+let delay = (ms, f) => Future.make(resolve =>
+  setTimeout(() => f() |> resolve, ms) |> ignore
+);
+
+let checkPromisedValue = (done_, expected, actual) => {
+  BsOspec.Cjs.equals(expected, actual);
+  done_();
+  Js.Promise.resolve(());
+};


### PR DESCRIPTION
Even if conversion from (js)Promise to Future is often sufficient
on the assumption that all following computation is done within the
Future monad, it is still sometimes necessary to convert Future
back to Promise. E.g. When writing aws lambdas the ultimate return
value must be a promise.