### PR TITLE
Add infix operators for mapOk/flatMapOk

### DIFF
--- a/src/Future.re
+++ b/src/Future.re
@@ -100,5 +100,5 @@ let tapError = (future, f) => future |. tap(r => switch(r) {
   | Ok(_) => ()
 });
 
-let (>>=) = (f, t) => flatMapOk(t, f);
-let (<*>) = (f, t) => mapOk(f, t);
+let (>>=) = flatMapOk;
+let (<$>) = mapOk;

--- a/src/Future.re
+++ b/src/Future.re
@@ -99,3 +99,6 @@ let tapError = (future, f) => future |. tap(r => switch(r) {
   | Belt.Result.Error(v) => f(v) |. ignore
   | Ok(_) => ()
 });
+
+let (>>=) = (f, t) => flatMapOk(t, f);
+let (<*>) = (f, t) => mapOk(f, t);

--- a/tests/TestFuture.re
+++ b/tests/TestFuture.re
@@ -118,11 +118,10 @@ describe("Future", () => {
 
 
 describe("Future Belt.Result", () => {
+  let ((>>=), (<$>)) = Future.((>>=), (<$>));
 
   test("mapOk", () => {
-    Belt.Result.Ok("two")
-    |. Future.value
-    |. Future.mapOk(s => s ++ "!")
+    (Belt.Result.Ok("two") |. Future.value <$> (s => s ++ "!"))
     |. Future.get(r => {
       Belt.Result.getExn(r) |. equals("two!");
     });
@@ -154,9 +153,10 @@ describe("Future Belt.Result", () => {
   });
 
   test("flatMapOk", () => {
-    Belt.Result.Ok("four")
-    |. Future.value
-    |. Future.flatMapOk(s => Belt.Result.Ok(s ++ "!") |. Future.value)
+    (
+      Belt.Result.Ok("four") |. Future.value
+      >>= (s => Belt.Result.Ok(s ++ "!") |. Future.value)
+    )
     |. Future.get(r => Belt.Result.getExn(r) |. equals("four!"));
 
     Belt.Result.Error("err4.1")

--- a/tests/TestFuture.re
+++ b/tests/TestFuture.re
@@ -270,7 +270,7 @@ describe("Future Belt.Result", () => {
     |. Future.get(r =>
       r
       |. Belt.Result.getExn
-      |. equals("infix ops rock!2")
+      |. equals("infix ops rock!")
     );
 
     Future.value(Belt.Result.Error("infix ops"))

--- a/tests/TestFuture.re
+++ b/tests/TestFuture.re
@@ -283,8 +283,11 @@ describe("Future Belt.Result", () => {
   });
 
   test(">>=", () => {
+    let appendToString = (appendedString, s) =>
+      (s ++ appendedString) |. Belt.Result.Ok |. Future.value;
+
     Future.value(Belt.Result.Ok("infix ops"))
-    >>= (s => (s ++ " still rock!") |. Belt.Result.Ok |. Future.value)
+    >>= appendToString(" still rock!")
     |. Future.get(r =>
       r
       |. Belt.Result.getExn
@@ -292,7 +295,7 @@ describe("Future Belt.Result", () => {
     );
 
     Future.value(Belt.Result.Error("infix ops"))
-    >>= (s => (s ++ " still suck!") |. Belt.Result.Ok |. Future.value)
+    >>= appendToString(" still sucks!")
     |. Future.get(r => switch (r) {
       | Ok(_) => raise(TestError("shouldn't be possible"))
       | Error(e) => e |. equals("infix ops");


### PR DESCRIPTION
I wanted to see at least what the interest would be in adding some infix operators to the codebase. I chose what I would think are the 2 most common methods to add them to and I lifted the operators from Haskell.