### PR TITLE
Map errors to exception in FutureJs.resultToPromise.

### DIFF
--- a/src/FutureJs.re
+++ b/src/FutureJs.re
@@ -33,9 +33,12 @@ let toPromise = future =>
     future->Future.get(value => resolve(. value))
   );
 
+exception FutureError;
+
 let resultToPromise = future =>
   Js.Promise.make((~resolve, ~reject) =>
     future
+    ->Future.mapError(_ => FutureError)
     ->Future.map(result =>
         switch (result) {
         | Belt.Result.Ok(result) => resolve(. result)

--- a/tests/TestFutureJs.re
+++ b/tests/TestFutureJs.re
@@ -113,8 +113,16 @@ describe("FutureJs", () => {
     |> Js.Promise.then_(checkPromisedValue(done_, "payload"))
   );
 
-  testAsync("resultToPromise (Error result)", done_ => {
+  testAsync("resultToPromise (Error exn)", done_ => {
     let err = TestError("error!");
+    delay(5, () => Belt.Result.Error(err))
+    |> FutureJs.resultToPromise
+    |> Js.Promise.then_(_ => raise(TestError("shouldn't be possible")))
+    |> Js.Promise.catch(checkPromisedValue(done_, err));
+  });
+
+  testAsync("resultToPromise (Error `PolymorphicVariant)", done_ => {
+    let err = `TestError;
     delay(5, () => Belt.Result.Error(err))
     |> FutureJs.resultToPromise
     |> Js.Promise.then_(_ => raise(TestError("shouldn't be possible")))


### PR DESCRIPTION
Allows Belt.Result Errors to contain non-exceptions before being sent to resultToPromise

closes #33 