### PR TITLE
Make recursive calls to flatMap stack safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,15 @@ somePromiseGetter()
 
 See [Composible Error Handling in OCaml][error-handling] for several strategies that you may employ.
 
+### Stack Safety
+
+By default this library is not stack safe, you will recieve a 'Maximum call stack size exceeded' error if you recurse too deeply. You can opt into stack safety by passing an optional parameter to the constructors of trampoline. This has a slight overhead. For example:
+
+```reason
+let stackSafe = Future.make(~executor=`trampoline, resolver);
+let stackSafeValue = Future.value(~executor=`trampoline, "Value");
+```
+
 ## TODO
 
 - [ ] Implement cancellation tokens

--- a/__tests__/TestFuture.re
+++ b/__tests__/TestFuture.re
@@ -313,7 +313,7 @@ describe("Future Belt.Result", () => {
   });
 
   testAsync("value recursion is stack safe", finish => {
-    let next = x => Future.value(x + 1);
+    let next = x => Future.value(~executor=`trampoline, x + 1);
     let numberOfLoops = 10000;
     let rec loop = x => {
       next(x)
@@ -330,7 +330,7 @@ describe("Future Belt.Result", () => {
   });
 
   testAsync("async recursion is stack safe", finish => {
-    let next = x => delay(1, () => x + 1);
+    let next = x => delay(~executor=`trampoline, 1, () => x + 1);
     let numberOfLoops = 1000;
     let rec loop = x => {
       next(x)

--- a/__tests__/TestFuture.re
+++ b/__tests__/TestFuture.re
@@ -311,4 +311,38 @@ describe("Future Belt.Result", () => {
         |> finish
       );
   });
+
+  testAsync("value recursion is stack safe", finish => {
+    let next = x => Future.value(x + 1);
+    let numberOfLoops = 10000;
+    let rec loop = x => {
+      next(x)
+      ->Future.flatMap(x' =>
+          if (x' == numberOfLoops) {
+            Future.value(x');
+          } else {
+            loop(x');
+          }
+        );
+    };
+    loop(0)
+    ->Future.get(r => r |> expect |> toEqual(numberOfLoops) |> finish);
+  });
+
+  testAsync("async recursion is stack safe", finish => {
+    let next = x => delay(1, () => x + 1);
+    let numberOfLoops = 1000;
+    let rec loop = x => {
+      next(x)
+      ->Future.flatMap(x' =>
+          if (x' == numberOfLoops) {
+            Future.value(x');
+          } else {
+            loop(x');
+          }
+        );
+    };
+    loop(0)
+    ->Future.get(r => r |> expect |> toEqual(numberOfLoops) |> finish);
+  });
 });

--- a/__tests__/TestUtil.re
+++ b/__tests__/TestUtil.re
@@ -5,4 +5,6 @@ type timeoutId;
 external setTimeout: ([@bs.uncurry] (unit => unit), int) => timeoutId = "";
 
 let delay = (~executor=`none, ms, f) =>
-  Future.make(~executor, resolve => setTimeout(() => f() |> resolve, ms) |> ignore);
+  Future.make(~executor, resolve =>
+    setTimeout(() => f() |> resolve, ms) |> ignore
+  );

--- a/__tests__/TestUtil.re
+++ b/__tests__/TestUtil.re
@@ -4,5 +4,5 @@ type timeoutId;
 [@bs.val] [@bs.val]
 external setTimeout: ([@bs.uncurry] (unit => unit), int) => timeoutId = "";
 
-let delay = (ms, f) =>
-  Future.make(resolve => setTimeout(() => f() |> resolve, ms) |> ignore);
+let delay = (~executor=`none, ms, f) =>
+  Future.make(~executor, resolve => setTimeout(() => f() |> resolve, ms) |> ignore);

--- a/src/Future.re
+++ b/src/Future.re
@@ -1,7 +1,9 @@
 type getFn('a) = ('a => unit) => unit;
 
+type executorOptions = [ | `none | `trampoline];
+
 type t('a) =
-  | Future(getFn('a));
+  | Future(getFn('a), executorOptions);
 
 let trampoline = {
   let running = ref(false);
@@ -23,9 +25,15 @@ let trampoline = {
     };
 };
 
-let make = resolver => {
+let make = (~executor: executorOptions=`none, resolver) => {
   let callbacks = ref([]);
   let data = ref(None);
+
+  let runCallback =
+    switch (executor) {
+    | `none => ((result, cb) => cb(result))
+    | `trampoline => ((result, cb) => trampoline(() => cb(result)))
+    };
 
   resolver(result =>
     switch (data^) {
@@ -33,7 +41,7 @@ let make = resolver => {
       data := Some(result);
       (callbacks^)
       ->Belt.List.reverse
-      ->Belt.List.forEach(cb => trampoline(() => cb(result)));
+      ->Belt.List.forEach(runCallback(result));
       /* Clean up memory usage */
       callbacks := [];
     | Some(_) => () /* Do nothing; theoretically not possible */
@@ -46,18 +54,20 @@ let make = resolver => {
       | Some(result) => trampoline(() => resolve(result))
       | None => callbacks := [resolve, ...callbacks^]
       },
+    executor,
   );
 };
 
-let value = x => make(resolve => resolve(x));
+let value = (~executor: executorOptions=`none, x) =>
+  make(~executor, resolve => resolve(x));
 
-let map = (Future(get), f) =>
-  make(resolve => get(result => resolve(f(result))));
+let map = (Future(get, executor), f) =>
+  make(~executor, resolve => get(result => resolve(f(result))));
 
-let flatMap = (Future(get), f) =>
-  make(resolve =>
+let flatMap = (Future(get, executor), f) =>
+  make(~executor, resolve =>
     get(result => {
-      let Future(get2) = f(result);
+      let Future(get2, _) = f(result);
       get2(resolve);
     })
   );
@@ -81,12 +91,12 @@ let rec all = futures =>
   | [] => value([])
   };
 
-let tap = (Future(get) as future, f) => {
+let tap = (Future(get, _) as future, f) => {
   get(f);
   future;
 };
 
-let get = (Future(getFn), f) => getFn(f);
+let get = (Future(getFn, _), f) => getFn(f);
 
 /* *
  * Future Belt.Result convenience functions,

--- a/src/Future.re
+++ b/src/Future.re
@@ -1,9 +1,9 @@
 type getFn('a) = ('a => unit) => unit;
 
-type executorOptions = [ | `none | `trampoline];
+type executorType = [ | `none | `trampoline];
 
 type t('a) =
-  | Future(getFn('a), executorOptions);
+  | Future(getFn('a), executorType);
 
 let trampoline = {
   let running = ref(false);
@@ -25,7 +25,7 @@ let trampoline = {
     };
 };
 
-let make = (~executor: executorOptions=`none, resolver) => {
+let make = (~executor: executorType=`none, resolver) => {
   let callbacks = ref([]);
   let data = ref(None);
 
@@ -51,14 +51,14 @@ let make = (~executor: executorOptions=`none, resolver) => {
   Future(
     resolve =>
       switch (data^) {
-      | Some(result) => trampoline(() => resolve(result))
+      | Some(result) => runCallback(result, resolve)
       | None => callbacks := [resolve, ...callbacks^]
       },
     executor,
   );
 };
 
-let value = (~executor: executorOptions=`none, x) =>
+let value = (~executor: executorType=`none, x) =>
   make(~executor, resolve => resolve(x));
 
 let map = (Future(get, executor), f) =>

--- a/src/Future.rei
+++ b/src/Future.rei
@@ -1,7 +1,8 @@
 type getFn('a) = ('a => unit) => unit;
-type t('a) = Future(getFn('a));
-let make: (('a => unit) => 'b) => t('a);
-let value: 'a => t('a);
+type executorType = [ `none | `trampoline ];
+type t('a);
+let make: (~executor: executorType=?, ('a => unit) => 'b) => t('a);
+let value: (~executor: executorType=?, 'a) => t('a);
 let map: (t('a), 'a => 'b) => t('b);
 let flatMap: (t('a), 'a => t('b)) => t('b);
 let map2: (t('a), t('b), ('a, 'b) => 'c) => t('c);


### PR DESCRIPTION
To make recursive algorithms easier to implement this pushes any
nested callbacks in flatMap onto a 'trampoline' which means only one
can run at any time. This is useful when synchronous futures are
created and used in recursive functions.

Without this patch the following test failure would occur:
``` Future Belt.Result › value recursion is stack safe

    RangeError: Maximum call stack size exceeded

      17 |           } else {
      18 |             data[0] = Caml_option.some(result);
    > 19 |             Belt_List.forEach(Belt_List.reverse(callbacks[0]), (function (cb) {
         |                       ^
      20 |                     return Curry._1(cb, result);
      21 |                   }));
      22 |             callbacks[0] = /* [] */0;

      at forEachU (node_modules/bs-platform/lib/js/belt_List.js:785:18)
      at Object.forEach (node_modules/bs-platform/lib/js/belt_List.js:799:10)
      at src/Future.bs.js:19:23
      at Object._1 (node_modules/bs-platform/lib/js/curry.js:65:12)
      at src/Future.bs.js:42:30
      at Object._1 (node_modules/bs-platform/lib/js/curry.js:65:12)
      at make (src/Future.bs.js:13:9)
      at Object.value (src/Future.bs.js:41:10)
      at loop (__tests__/TestFuture.bs.js:364:54)
      at __tests__/TestFuture.bs.js:368:48
```

resolves #44 