### PR TITLE
Implement error transformer for resultToPromise

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,13 @@ Convenience functions for interop with JavaScript land.
 - `FutureJs.toPromise(future)`
   - `future` is any `Future.t('a)` which is transformed into a
     `Js.Promise.t('a)`. Always resolves, never rejects the promise.
-- `FutureJs.resultToPromise(future)`
+- `FutureJs.resultToPromise(future, errorTransformer)`
   - `future` is the `Future.t(Belt.Result('a, 'e))` which is transformed into a
     `Js.Promise.t('a)`. Resolves the promise on Ok result and rejects on Error result.
+  - `errorTransformer` allows you to determine how `Belt.Result.Error` (of 'b) type
+    objects will be transformed before they are returned wrapped within
+    a `Js.Promise.t`.  This allows you to implement the error handling
+    method which best meets your application's needs.
 
 Example use:
 

--- a/__tests__/TestFutureJs.re
+++ b/__tests__/TestFutureJs.re
@@ -98,7 +98,7 @@ describe("FutureJs", () => {
 
   testPromise("resultToPromise (Ok result)", () =>
     delay(5, () => Belt.Result.Ok("payload"))
-    |> FutureJs.resultToPromise
+    |> FutureJs.resultToPromise(_, x => TestError(Js.String.make(x)))
     |> Js.Promise.catch(_ => raise(TestError("shouldn't be possible")))
     |> Js.Promise.then_(x =>
          Js.Promise.resolve(x |> expect |> toEqual("payload"))
@@ -108,11 +108,11 @@ describe("FutureJs", () => {
   testPromise("resultToPromise (Error exn)", () => {
     let err = TestError("error!");
     delay(5, () => Belt.Result.Error(err))
-    |> FutureJs.resultToPromise
+    |> FutureJs.resultToPromise(_, x => x)
     |> Js.Promise.then_(_ => raise(TestError("shouldn't be possible")))
-    |> Js.Promise.catch(_ =>
+    |> Js.Promise.catch(x =>
          Js.Promise.resolve(
-           pass // Going from Future to Js.Promise loses information...
+           Js.String.make(x) |> expect |> toEqual(Js.String.make(err))
          )
        );
   });
@@ -120,11 +120,11 @@ describe("FutureJs", () => {
   testPromise("resultToPromise (Error `PolymorphicVariant)", () => {
     let err = `TestError;
     delay(5, () => Belt.Result.Error(err))
-    |> FutureJs.resultToPromise
+    |> FutureJs.resultToPromise(_, x => TestError(Js.String.make(x)))
     |> Js.Promise.then_(_ => raise(TestError("shouldn't be possible")))
-    |> Js.Promise.catch(_ =>
+    |> Js.Promise.catch(x =>
          Js.Promise.resolve(
-           pass // Going from Future to Js.Promise loses information...
+           Js.String.make(x) |> expect |> toMatchRe(Js.Re.fromString("^.*" ++ Js.String.make(err) ++ "$"))
          )
        );
   });

--- a/src/FutureJs.re
+++ b/src/FutureJs.re
@@ -33,12 +33,10 @@ let toPromise = future =>
     future->Future.get(value => resolve(. value))
   );
 
-exception FutureError;
-
-let resultToPromise = future =>
+let resultToPromise = (future, errorTransformer) =>
   Js.Promise.make((~resolve, ~reject) =>
     future
-    ->Future.mapError(_ => FutureError)
+    ->Future.mapError(errorTransformer)
     ->Future.map(result =>
         switch (result) {
         | Belt.Result.Ok(result) => resolve(. result)

--- a/src/FutureJs.rei
+++ b/src/FutureJs.rei
@@ -2,5 +2,6 @@ let fromPromise:
   (Js.Promise.t('a), Js.Promise.error => 'b) =>
   Future.t(Belt.Result.t('a, 'b));
 let toPromise: Future.t('a) => Js.Promise.t('a);
-exception FutureError;
-let resultToPromise: Future.t(Belt.Result.t('a, 'b)) => Js.Promise.t('a);
+let resultToPromise:
+  (Future.t(Belt.Result.t('a, 'b)), 'b => exn) =>
+  Js.Promise.t('a);


### PR DESCRIPTION
Previous change to the resultToPromise function throws the contents of errors away replacing it with meaningless FutureError. This PR fixes this bug, but is not backwards compatible because there is a new parameter `errorTransformer`.