### PR TITLE
Update for bucklescript 8

### DIFF
--- a/src/Future.re
+++ b/src/Future.re
@@ -46,7 +46,8 @@ let make = (~executor: executorType=`none, resolver) => {
       callbacks := [];
     | Some(_) => () /* Do nothing; theoretically not possible */
     }
-  );
+  )
+  ->ignore;
 
   Future(
     resolve =>


### PR DESCRIPTION
Updates for BuckleScript 8 changes.

```
/node_modules/reason-future/src/FutureJs.re 18:5-28:8

  16 │ let fromPromise = (promise, errorTransformer) =>
  17 │   Future.make(callback =>
  18 │     promise
  19 │     |> Js.Promise.then_(res =>
   . │ ...
  27 │          |> Js.Promise.resolve
  28 │        )
  29 │   );
  30 │

  This has type:
    Js.Promise.t(unit) (defined as Js.Promise.t(unit))
  But somewhere wanted:
    unit
```


bsrefmt made a few other minor changes too automatically.  I can back those out if you'd like.